### PR TITLE
Add ability to disable ssl verification.

### DIFF
--- a/src/async_kinesis_client/kinesis_consumer.py
+++ b/src/async_kinesis_client/kinesis_consumer.py
@@ -162,7 +162,7 @@ class AsyncKinesisConsumer(StoppableProcess):
 
     def __init__(
             self, stream_name, checkpoint_table=None, host_key=None, shard_iterator_type=None,
-            iterator_timestamp=None, shard_iterators=None, recover_from_dynamo=False):
+            iterator_timestamp=None, shard_iterators=None, recover_from_dynamo=False, verify_ssl=True):
         """
         Initialize Async Kinesis Consumer
         :param stream_name:         stream name to read from
@@ -174,6 +174,9 @@ class AsyncKinesisConsumer(StoppableProcess):
                                     others
         :param recover_from_dynamo  If True, try to recover last read sequence number from DynamoDB during the initialization
                                     If successful, shard_iterator_type will be ignored
+        :param verify_ssl: (bool)   If False, the underlying aioboto3 client will not verify the ssl certificates. Value
+                                    passes through the the creation of the kinesis client. Defaults to True, which means
+                                    we will verify ssl certs on connect.
         """
 
         super(AsyncKinesisConsumer, self).__init__()
@@ -187,7 +190,7 @@ class AsyncKinesisConsumer(StoppableProcess):
             raise RuntimeError('Can not use recover_from_dynamo without checkpoint table')
         self.recover_from_dynamodb = recover_from_dynamo
 
-        self.kinesis_client = aioboto3.client('kinesis')
+        self.kinesis_client = aioboto3.client('kinesis', verify=verify_ssl)
 
         self.checkpoint_table = checkpoint_table
         self.checkpoint_callback = None

--- a/src/async_kinesis_client/kinesis_producer.py
+++ b/src/async_kinesis_client/kinesis_producer.py
@@ -21,7 +21,7 @@ def _get_default_partition_key():
 
 class AsyncKinesisProducer:
 
-    def __init__(self, stream_name, ordered=True):
+    def __init__(self, stream_name, ordered=True, verify_ssl=True):
 
         self.stream_name = stream_name
         self.ordered = ordered
@@ -31,7 +31,7 @@ class AsyncKinesisProducer:
         self.record_buf = []
         self.buf_size = 0
 
-        client = aioboto3.client('kinesis')
+        client = aioboto3.client('kinesis', verify=verify_ssl)
         self.kinesis_client = RetriableKinesisProducer(client=client)
         log.debug("Configured kinesis producer for stream '%s'; ordered=%s",
                   stream_name, ordered)


### PR DESCRIPTION
Thoughts on this?

Only other solution I see is to pass a list of client options that are effectively pass through for your library, so that the underlying aws libs could change without any code changes needed here...