### PR TITLE
Make async-kinesis-client DynamoDB checkpoint table compatible with aioboto3 context manager requirement

### DIFF
--- a/src/async_kinesis_client/dynamodb.py
+++ b/src/async_kinesis_client/dynamodb.py
@@ -20,20 +20,19 @@ class DynamoDB:
 
     DEFAULT_MAX_RETRIES = 5
 
-    def __init__(self, table_name, shard_id, max_retries=DEFAULT_MAX_RETRIES, host_key=None):
+    def __init__(self, table, shard_id, max_retries=DEFAULT_MAX_RETRIES, host_key=None):
         """
         Initialize DynamoDB
-        :param table_name:  DynamoDB table name
+        :param table:  DynamoDB table object
         :param shard_id:    ShardId as returned by kinesis client
         :param max_retries: Max retries for communicating with DynamoDB
         :param host_key:    Key to identify reader. If no key provided, defaults to FQDN
         """
-        self.table_name = table_name
         self.shard_id = shard_id
         self.shard = {}
         self.host_key = host_key or socket.getfqdn()
-        self.lock_holding_time = None
-        table = aioboto3.resource('dynamodb').Table(self.table_name)
+        self.lock_holding_time = 0
+        self.table_name = table.table_name
         self.dynamo_table = RetriableDynamoDB(table=table, retries=max_retries, retry_sleep_time=1)
 
     async def checkpoint(self, seq):

--- a/src/async_kinesis_client/kinesis_consumer.py
+++ b/src/async_kinesis_client/kinesis_consumer.py
@@ -351,7 +351,7 @@ class AsyncKinesisConsumer(StoppableProcess):
             # obtain lock if we don't have it, or refresh if we're already holding it
             if dynamodb is None:
                 dynamodb = DynamoDB(
-                    table_name=self.checkpoint_table,
+                    table=self.checkpoint_table,
                     shard_id=shard_id,
                     host_key=self.host_key
                 )


### PR DESCRIPTION
As mentioned in https://github.com/whale2/async-kinesis-client/issues/10#issue-625379437, `aiobotocore==1.0.4` requires context managers when instantiating clients/resources. Consequently, we run into issues when passing a DynamoDB table name to the `checkpoint_table` kwarg of the `AsyncKinesisConsumer` class and attempt to instantiate the table in src/async_kinesis_client/dynamodb.py file using `table = aioboto3.resource('dynamodb').Table(self.table_name)` syntax.

Instead of passing in a table name to the `checkpoint_table` kwarg of the `AsyncKinesisConsumer` class, this change allows one instead to pass a table object to that kwarg like so:

```python
    async with session.create_client(
        "kinesis",
        region_name="us-west-2",
        endpoint_url="https://kinesis.us-west-2.amazonaws.com",
    ) as client:
        async with aioboto3.resource(
            "dynamodb", region_name="us-west-2"
        ) as dynamo_resource:
            table = await dynamo_resource.Table("kinesis-state-test")
            consumer = AsyncKinesisConsumer(
                stream_name="kinesis-stream-test",
                checkpoint_table=table,
                custom_kinesis_client=client,
            )

            # consumer will yield existing shards and will continue yielding
            # new shards if re-sharding happens
            async for shard_reader in consumer.get_shard_readers():
                asyncio.ensure_future(read_records(shard_reader))

```